### PR TITLE
ci(release): add sync release manifest PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,13 +73,20 @@ jobs:
           jq --arg tag "${RELEASE_TAG//v/}" '.["."] = $tag' $MANIFEST_PATH > temp.json \
             && mv temp.json $MANIFEST_PATH
 
-      - name: Commit change
+      - name: Commit sync prerelease manifest
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b sync-prerelease-manifest
           git add . $MANIFEST_PATH
           git commit -m "chore: sync release manifests"
-          git push
+          git push --set-upstream origin sync-prerelease-manifest
+
+      - name: Create sync release manifests Pull Request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create --title "chore: sync release manifests" --body "This PR syncs the release manifests." --label "autorelease: pending"
 
   post-release:
     name: Post Release Steps


### PR DESCRIPTION
- workflow has no permission to sync manifest in main
- alternative is to do it via PR this prepares the PR which needs to be approved by a maintainer